### PR TITLE
move whisperer dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'rake'
-gem 'whisperer', path: '../whisperer'
+gem 'whisperer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,39 @@
-PATH
-  remote: ../whisperer
+GEM
+  remote: https://rubygems.org/
   specs:
-    whisperer (0.0.1)
+    activesupport (5.0.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
+    concurrent-ruby (1.0.2)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
+    equalizer (0.0.11)
+    factory_girl (4.7.0)
+      activesupport (>= 3.0.0)
+    i18n (0.7.0)
+    ice_nine (0.11.2)
+    minitest (5.9.1)
+    multi_json (1.12.1)
+    rainbow (2.1.0)
+    rake (10.1.1)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    vcr (2.9.3)
+    virtus (1.0.5)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
+    whisperer (0.0.2)
       activesupport
       factory_girl (~> 4)
       multi_json
@@ -10,46 +42,12 @@ PATH
       vcr (~> 2)
       virtus (~> 1)
 
-GEM
-  remote: https://rubygems.org/
-  specs:
-    activesupport (4.1.7)
-      i18n (~> 0.6, >= 0.6.9)
-      json (~> 1.7, >= 1.7.7)
-      minitest (~> 5.1)
-      thread_safe (~> 0.1)
-      tzinfo (~> 1.1)
-    axiom-types (0.1.1)
-      descendants_tracker (~> 0.0.4)
-      ice_nine (~> 0.11.0)
-      thread_safe (~> 0.3, >= 0.3.1)
-    coercible (1.0.0)
-      descendants_tracker (~> 0.0.1)
-    descendants_tracker (0.0.4)
-      thread_safe (~> 0.3, >= 0.3.1)
-    equalizer (0.0.9)
-    factory_girl (4.5.0)
-      activesupport (>= 3.0.0)
-    i18n (0.6.11)
-    ice_nine (0.11.0)
-    json (1.8.1)
-    minitest (5.4.2)
-    multi_json (1.10.1)
-    rainbow (2.0.0)
-    rake (10.1.1)
-    thread_safe (0.3.4)
-    tzinfo (1.2.2)
-      thread_safe (~> 0.1)
-    vcr (2.9.3)
-    virtus (1.0.3)
-      axiom-types (~> 0.1)
-      coercible (~> 1.0)
-      descendants_tracker (~> 0.0, >= 0.0.3)
-      equalizer (~> 0.0, >= 0.0.9)
-
 PLATFORMS
   ruby
 
 DEPENDENCIES
   rake
-  whisperer!
+  whisperer
+
+BUNDLED WITH
+   1.13.1


### PR DESCRIPTION
Before this change, this repo is dependent on also having the
whisperer repo checked out and next to it in your file system.

After this commit, we just look for whisperer on rubygems, like
any other gem we'd depend on.

`rake whisperer:cassettes:generate_all` still runs properly.
